### PR TITLE
한글 조합 규칙 중 잘못된 부분을 수정하고 세벌식 자판군의 중성 순서를 교정합니다.

### DIFF
--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -237,9 +237,24 @@ struct _HangulInputContext {
 
 #include "hangulkeyboard.h"
 
-static const HangulCombination hangul_combination_default = {
-    N_ELEMENTS(hangul_combination_table_default),
-    (HangulCombinationItem*)hangul_combination_table_default
+static const HangulCombination hangul_combination_2 = {
+    N_ELEMENTS(hangul_combination_table_2),
+    (HangulCombinationItem*)hangul_combination_table_2
+};
+
+static const HangulCombination hangul_combination_3 = {
+    N_ELEMENTS(hangul_combination_table_3),
+    (HangulCombinationItem*)hangul_combination_table_3
+};
+
+static const HangulCombination hangul_combination_390 = {
+    N_ELEMENTS(hangul_combination_table_390),
+    (HangulCombinationItem*)hangul_combination_table_390
+};
+
+static const HangulCombination hangul_combination_3sun = {
+    N_ELEMENTS(hangul_combination_table_3sun),
+    (HangulCombinationItem*)hangul_combination_table_3sun
 };
 
 static const HangulCombination hangul_combination_romaja = {
@@ -262,7 +277,7 @@ static const HangulKeyboard hangul_keyboard_2 = {
     "2", 
     N_("Dubeolsik"), 
     (ucschar*)hangul_keyboard_table_2,
-    &hangul_combination_default
+    &hangul_combination_2
 };
 
 static const HangulKeyboard hangul_keyboard_2y = {
@@ -278,7 +293,7 @@ static const HangulKeyboard hangul_keyboard_32 = {
     "32",
     N_("Sebeolsik Dubeol Layout"),
     (ucschar*)hangul_keyboard_table_32,
-    &hangul_combination_default
+    &hangul_combination_2
 };
 
 static const HangulKeyboard hangul_keyboard_390 = {
@@ -286,7 +301,7 @@ static const HangulKeyboard hangul_keyboard_390 = {
     "39",
     N_("Sebeolsik 390"),
     (ucschar*)hangul_keyboard_table_390,
-    &hangul_combination_default
+    &hangul_combination_390
 };
 
 static const HangulKeyboard hangul_keyboard_3final = {
@@ -294,7 +309,7 @@ static const HangulKeyboard hangul_keyboard_3final = {
     "3f",
     N_("Sebeolsik Final"),
     (ucschar*)hangul_keyboard_table_3final,
-    &hangul_combination_default
+    &hangul_combination_3
 };
 
 static const HangulKeyboard hangul_keyboard_3sun = {
@@ -302,7 +317,7 @@ static const HangulKeyboard hangul_keyboard_3sun = {
     "3s",
     N_("Sebeolsik Noshift"),
     (ucschar*)hangul_keyboard_table_3sun,
-    &hangul_combination_default
+    &hangul_combination_3sun,
 };
 
 static const HangulKeyboard hangul_keyboard_3yet = {

--- a/hangul/hangulkeyboard.h
+++ b/hangul/hangulkeyboard.h
@@ -1177,12 +1177,7 @@ static const ucschar hangul_keyboard_table_ahn[] = {
     0x0000      /* 0x7F delete                                       */
 };
 
-static const HangulCombinationItem hangul_combination_table_default[] = {
-  { 0x11001100, 0x1101 }, /* choseong  kiyeok + kiyeok  = ssangkiyeok   */
-  { 0x11031103, 0x1104 }, /* choseong  tikeut + tikeut  = ssangtikeut   */
-  { 0x11071107, 0x1108 }, /* choseong  pieup  + pieup   = ssangpieup    */
-  { 0x11091109, 0x110a }, /* choseong  sios   + sios    = ssangsios     */
-  { 0x110c110c, 0x110d }, /* choseong  cieuc  + cieuc   = ssangcieuc    */
+static const HangulCombinationItem hangul_combination_table_2[] = {
   { 0x11691161, 0x116a }, /* jungseong o      + a       = wa            */
   { 0x11691162, 0x116b }, /* jungseong o      + ae      = wae           */
   { 0x11691175, 0x116c }, /* jungseong o      + i       = oe            */
@@ -1190,7 +1185,6 @@ static const HangulCombinationItem hangul_combination_table_default[] = {
   { 0x116e1166, 0x1170 }, /* jungseong u      + e       = we            */
   { 0x116e1175, 0x1171 }, /* jungseong u      + i       = wi            */
   { 0x11731175, 0x1174 }, /* jungseong eu     + i       = yi            */
-  { 0x11a811a8, 0x11a9 }, /* jongseong kiyeok + kiyeok  = ssangekiyeok  */
   { 0x11a811ba, 0x11aa }, /* jongseong kiyeok + sios    = kiyeok-sois   */
   { 0x11ab11bd, 0x11ac }, /* jongseong nieun  + cieuc   = nieun-cieuc   */
   { 0x11ab11c2, 0x11ad }, /* jongseong nieun  + hieuh   = nieun-hieuh   */
@@ -1202,7 +1196,85 @@ static const HangulCombinationItem hangul_combination_table_default[] = {
   { 0x11af11c1, 0x11b5 }, /* jongseong rieul  + phieuph = rieul-phieuph */
   { 0x11af11c2, 0x11b6 }, /* jongseong rieul  + hieuh   = rieul-hieuh   */
   { 0x11b811ba, 0x11b9 }, /* jongseong pieup  + sios    = pieup-sios    */
-  { 0x11ba11ba, 0x11bb }, /* jongseong sios   + sios    = ssangsios     */
+};
+
+static const HangulCombinationItem hangul_combination_table_3[] = {
+    { 0x11001100, 0x1101 }, /* choseong  kiyeok + kiyeok  = ssangkiyeok   */
+    { 0x11031103, 0x1104 }, /* choseong  tikeut + tikeut  = ssangtikeut   */
+    { 0x11071107, 0x1108 }, /* choseong  pieup  + pieup   = ssangpieup    */
+    { 0x11091109, 0x110a }, /* choseong  sios   + sios    = ssangsios     */
+    { 0x110c110c, 0x110d }, /* choseong  cieuc  + cieuc   = ssangcieuc    */
+    { 0x11611169, 0x116a }, /* jungseong a      + o       = wa            */
+    { 0x11621169, 0x116b }, /* jungseong ae     + o       = wae           */
+    { 0x1165116e, 0x116f }, /* jungseong eo     + u       = weo           */
+    { 0x1166116e, 0x1170 }, /* jungseong e      + u       = we            */
+    { 0x11691161, 0x116a }, /* jungseong o      + a       = wa            */
+    { 0x11691162, 0x116b }, /* jungseong o      + ae      = wae           */
+    { 0x11691175, 0x116c }, /* jungseong o      + i       = oe            */
+    { 0x116e1165, 0x116f }, /* jungseong u      + eo      = weo           */
+    { 0x116e1166, 0x1170 }, /* jungseong u      + e       = we            */
+    { 0x116e1175, 0x1171 }, /* jungseong u      + i       = wi            */
+    { 0x11751169, 0x116c }, /* jungseong i      + o       = oe            */
+    { 0x1175116e, 0x1171 }, /* jungseong i      + u       = wi            */
+};
+
+static const HangulCombinationItem hangul_combination_table_390[] = {
+    { 0x11001100, 0x1101 }, /* choseong  kiyeok + kiyeok  = ssangkiyeok   */
+    { 0x11031103, 0x1104 }, /* choseong  tikeut + tikeut  = ssangtikeut   */
+    { 0x11071107, 0x1108 }, /* choseong  pieup  + pieup   = ssangpieup    */
+    { 0x11091109, 0x110a }, /* choseong  sios   + sios    = ssangsios     */
+    { 0x110c110c, 0x110d }, /* choseong  cieuc  + cieuc   = ssangcieuc    */
+    { 0x11611169, 0x116a }, /* jungseong a      + o       = wa            */
+    { 0x11621169, 0x116b }, /* jungseong ae     + o       = wae           */
+    { 0x1165116e, 0x116f }, /* jungseong eo     + u       = weo           */
+    { 0x1166116e, 0x1170 }, /* jungseong e      + u       = we            */
+    { 0x11691161, 0x116a }, /* jungseong o      + a       = wa            */
+    { 0x11691162, 0x116b }, /* jungseong o      + ae      = wae           */
+    { 0x11691175, 0x116c }, /* jungseong o      + i       = oe            */
+    { 0x116e1165, 0x116f }, /* jungseong u      + eo      = weo           */
+    { 0x116e1166, 0x1170 }, /* jungseong u      + e       = we            */
+    { 0x116e1175, 0x1171 }, /* jungseong u      + i       = wi            */
+    { 0x11751169, 0x116c }, /* jungseong i      + o       = oe            */
+    { 0x1175116e, 0x1171 }, /* jungseong i      + u       = wi            */
+    { 0x11a811ba, 0x11aa }, /* jongseong kiyeok + sios    = kiyeok-sois   */
+    { 0x11ab11bd, 0x11ac }, /* jongseong nieun  + cieuc   = nieun-cieuc   */
+    { 0x11af11b8, 0x11b2 }, /* jongseong rieul  + pieup   = rieul-pieup   */
+    { 0x11af11ba, 0x11b3 }, /* jongseong rieul  + sios    = rieul-sios    */
+    { 0x11af11c0, 0x11b4 }, /* jongseong rieul  + thieuth = rieul-thieuth */
+    { 0x11af11c1, 0x11b5 }, /* jongseong rieul  + phieuph = rieul-phieuph */
+};
+
+static const HangulCombinationItem hangul_combination_table_3sun[] = {
+    { 0x11001100, 0x1101 }, /* choseong  kiyeok + kiyeok  = ssangkiyeok   */
+    { 0x11031103, 0x1104 }, /* choseong  tikeut + tikeut  = ssangtikeut   */
+    { 0x11071107, 0x1108 }, /* choseong  pieup  + pieup   = ssangpieup    */
+    { 0x11091109, 0x110a }, /* choseong  sios   + sios    = ssangsios     */
+    { 0x110c110c, 0x110d }, /* choseong  cieuc  + cieuc   = ssangcieuc    */
+    { 0x11611169, 0x116a }, /* jungseong a      + o       = wa            */
+    { 0x11621169, 0x116b }, /* jungseong ae     + o       = wae           */
+    { 0x1165116e, 0x116f }, /* jungseong eo     + u       = weo           */
+    { 0x1166116e, 0x1170 }, /* jungseong e      + u       = we            */
+    { 0x11691161, 0x116a }, /* jungseong o      + a       = wa            */
+    { 0x11691162, 0x116b }, /* jungseong o      + ae      = wae           */
+    { 0x11691175, 0x116c }, /* jungseong o      + i       = oe            */
+    { 0x116e1165, 0x116f }, /* jungseong u      + eo      = weo           */
+    { 0x116e1166, 0x1170 }, /* jungseong u      + e       = we            */
+    { 0x116e1175, 0x1171 }, /* jungseong u      + i       = wi            */
+    { 0x11751169, 0x116c }, /* jungseong i      + o       = oe            */
+    { 0x1175116e, 0x1171 }, /* jungseong i      + u       = wi            */
+    { 0x11a811a8, 0x11a9 }, /* jongseong kiyeok + kiyeok  = ssangekiyeok  */
+    { 0x11a811ba, 0x11aa }, /* jongseong kiyeok + sios    = kiyeok-sois   */
+    { 0x11ab11bd, 0x11ac }, /* jongseong nieun  + cieuc   = nieun-cieuc   */
+    { 0x11ab11c2, 0x11ad }, /* jongseong nieun  + hieuh   = nieun-hieuh   */
+    { 0x11af11a8, 0x11b0 }, /* jongseong rieul  + kiyeok  = rieul-kiyeok  */
+    { 0x11af11b7, 0x11b1 }, /* jongseong rieul  + mieum   = rieul-mieum   */
+    { 0x11af11b8, 0x11b2 }, /* jongseong rieul  + pieup   = rieul-pieup   */
+    { 0x11af11ba, 0x11b3 }, /* jongseong rieul  + sios    = rieul-sios    */
+    { 0x11af11c0, 0x11b4 }, /* jongseong rieul  + thieuth = rieul-thieuth */
+    { 0x11af11c1, 0x11b5 }, /* jongseong rieul  + phieuph = rieul-phieuph */
+    { 0x11af11c2, 0x11b6 }, /* jongseong rieul  + hieuh   = rieul-hieuh   */
+    { 0x11b811ba, 0x11b9 }, /* jongseong pieup  + sios    = pieup-sios    */
+    { 0x11ba11ba, 0x11bb }, /* jongseong sios   + sios    = ssangsios     */
 };
 
 static const HangulCombinationItem hangul_combination_table_romaja[] = {


### PR DESCRIPTION
두벌식 자판에서 자음을 연이어 입력하여 겹자음을 입력하던 규칙을 제거합니다. (ㄱ+ㄱ->ㄲ => ㄱ+ㄱ->ㄲ)
세벌식 자판군의 중성 조합 순서가 뒤집혀도 허용합니다. (ㅏ+ㅗ->ㅏㅗ => ㅏ+ㅗ->ㅘ)
세벌식 자판군의 종성 ㅆ, ㅢ 조합을 모두 제거합니다.
세벌식 최종 자판의 종성 조합 규칙을 모두 제거합니다.
세벌식 390 자판의 불필요한 종성 조합 규칙을 모두 제거합니다.
