### PR TITLE
세벌식 3-2011 자판 및 3-2012 자판 추가

### DIFF
--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -329,6 +329,22 @@ static const HangulKeyboard hangul_keyboard_ahn = {
     &hangul_combination_ahn
 };
 
+static const HangulKeyboard hangul_keyboard_3_2011 = {
+    HANGUL_KEYBOARD_TYPE_JASO,
+    "3-2011",
+    N_("Sebeolsik 3-2011"),
+    (ucschar*)hangul_keyboard_table_3_2011,
+    &hangul_combination_full
+};
+
+static const HangulKeyboard hangul_keyboard_3_2012 = {
+    HANGUL_KEYBOARD_TYPE_JASO,
+    "3-2012",
+    N_("Sebeolsik 3-2012"),
+    (ucschar*)hangul_keyboard_table_3_2012,
+    &hangul_combination_full
+};
+
 static const HangulKeyboard* hangul_keyboards[] = {
     &hangul_keyboard_2,
     &hangul_keyboard_2y,
@@ -336,6 +352,8 @@ static const HangulKeyboard* hangul_keyboards[] = {
     &hangul_keyboard_3final,
     &hangul_keyboard_3sun,
     &hangul_keyboard_3yet,
+    &hangul_keyboard_3_2011,
+    &hangul_keyboard_3_2012,
     &hangul_keyboard_32,
     &hangul_keyboard_romaja,
     &hangul_keyboard_ahn,


### PR DESCRIPTION
3-2011 자판은 공병우 최종 자판(3-91 자판)의 개선안이고, 3-2012 자판은 3-90 자판의 개선안입니다.
두 자판을 목록에 추가했습니다.

3-2012 자판에 대한 설명 : http://pat.im/938
3-2011 자판에 대한 설명 : http://pat.im/855
