### PR TITLE
사전 검색 함수 `hanja_table_search_prefix` 추가

### DIFF
--- a/hangul/hangul.h
+++ b/hangul/hangul.h
@@ -139,6 +139,7 @@ HanjaTable*  hanja_table_load(const char *filename);
 HanjaList*   hanja_table_match_exact(const HanjaTable* table, const char *key);
 HanjaList*   hanja_table_match_prefix(const HanjaTable* table, const char *key);
 HanjaList*   hanja_table_match_suffix(const HanjaTable* table, const char *key);
+HanjaList*   hanja_table_search_prefix(const HanjaTable* table, const char *key);
 void         hanja_table_delete(HanjaTable *table);
 
 int          hanja_list_get_size(const HanjaList *list);


### PR DESCRIPTION
`hanja_table_match_prefix`에서는 '삼국사기'를 검색해 '삼국사기', '삼국', '삼'을
찾는다면 새로 추가한 `hanja_table_search_prefix`에서는 반대로 '삼국'을 검색해
'삼국', '삼국사기' 등 '삼국' 접두사를 가진 모든 단어를 찾는다.
