### PR TITLE
Fixed compilation error

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,16 +1,43 @@
 #!/bin/sh
+# Run this to generate all the initial makefiles, etc.
 
-
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
 test -f ChangeLog || touch ChangeLog
+test -f config.rpath || touch config.rpath
 
-libtoolize=`which glibtoolize`
-if test -z "$libtoolize"; then
-    libtoolize=libtoolize
+olddir=`pwd`
+cd "$srcdir"
+
+mkdir -p m4
+
+PKGCONFIG=`which pkg-config`
+if test -z "$PKGCONFIG"; then
+    echo "pkg-config not found, please install pkg-config"
+    exit 1
 fi
 
-intltoolize --copy --force
-$libtoolize --automake --copy --force
-aclocal $ACLOCAL_AMFLAGS
-autoheader
-automake --add-missing --copy
-autoconf
+LIBTOOLIZE=`which libtoolize`
+if test -z $LIBTOOLIZE; then
+    echo "libtoolize not found, please install libtool package"
+    exit 1
+fi
+
+INTLTOOLIZE=`which intltoolize`
+if test -z $INTLTOOLIZE; then
+    echo "intltoolize not found, please install intltool package"
+    exit 1
+else
+    intltoolize --force --copy --automake || exit $?
+fi
+
+AUTORECONF=`which autoreconf`
+if test -z $AUTORECONF; then
+    echo "autoreconf not found, please install autoconf package"
+    exit 1
+else
+    autoreconf --force --install --verbose || exit $?
+fi
+
+cd "$olddir"
+test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"


### PR DESCRIPTION
libhangul 을 컴파일 시도를 하면 아래처럼 에러가 나고 컴파일이 되지 않습니다.
이 패치는 컴파일 에러를 해결하는 패치입니다.

```
hodong@debian:~/libhangul$ ls
AUTHORS     bindings      COPYING  doc     libhangul.pc.in  NEWS  README  tools
autogen.sh  configure.ac  data     hangul  Makefile.am      po    test
hodong@debian:~/libhangul$ ./autogen.sh
You should add the contents of '/usr/share/aclocal/intltool.m4' to 'aclocal.m4'.
configure.ac:30: installing './compile'
configure.ac:32: installing './config.guess'
configure.ac:61: error: required file './config.rpath' not found
configure.ac:32: installing './config.sub'
configure.ac:6: installing './install-sh'
configure.ac:6: installing './missing'
Makefile.am: installing './INSTALL'
data/keyboards/Makefile.am:34: warning: '%'-style pattern rules are a GNU make extension
data/keyboards/Makefile.am:42: warning: '%'-style pattern rules are a GNU make extension
hangul/Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
hodong@debian:~/libhangul$ ls
aclocal.m4      compile       COPYING  install-sh       NEWS
AUTHORS         config.guess  data     libhangul.pc.in  po
autogen.sh      config.h.in   depcomp  ltmain.sh        README
autom4te.cache  config.sub    doc      m4               test
bindings        configure     hangul   Makefile.am      test-driver
ChangeLog       configure.ac  INSTALL  missing          tools
hodong@debian:~/libhangul$ make
make: *** No targets specified and no makefile found.  Stop.
```