### PR TITLE
Remove compiler warnings with -Wpedantic (#44)

### DIFF
--- a/hangul/hangul.h
+++ b/hangul/hangul.h
@@ -23,7 +23,7 @@
 #include <inttypes.h>
 
 #ifdef __GNUC__
-#define LIBHANGUL_DEPRECATED __attribute__((deprecated));
+#define LIBHANGUL_DEPRECATED __attribute__((deprecated))
 #else
 #define LIBHANGUL_DEPRECATED
 #endif

--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -1411,10 +1411,10 @@ void hangul_ic_connect_callback(HangulInputContext* hic, const char* event,
 	return;
 
     if (strcasecmp(event, "translate") == 0) {
-	hic->on_translate      = (HangulOnTranslate)callback;
+        *(void**)(&hic->on_translate) = callback;
 	hic->on_translate_data = user_data;
     } else if (strcasecmp(event, "transition") == 0) {
-	hic->on_transition      = (HangulOnTransition)callback;
+        *(void**)(&hic->on_transition) = callback;
 	hic->on_transition_data = user_data;
     }
 }

--- a/test/hangul.c
+++ b/test/hangul.c
@@ -46,6 +46,7 @@ void ucs4_to_utf8(char *buf, const ucschar *ucs4, size_t bufsize)
     outbuf = buf;
     outbytesleft = bufsize;
     ret = iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+    (void)ret;
 
     iconv_close(cd);
 


### PR DESCRIPTION
pedantic 옵션을 추가했을 때 발생하는 워닝을 제거한다.
다른 워닝이 발생하는 곳도 같이 수정한다.

https://github.com/libhangul/libhangul/issues/44