### PR TITLE
Add LIBHANGUL_KEYBOARD_PATH environment variable feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,11 @@ test/Makefile
 tools/Makefile
 ])
 
+AC_CONFIG_LINKS([
+data/keyboards/hangul-combination-default.xml:data/keyboards/hangul-combination-default.xml
+data/keyboards/hangul-combination-full.xml:data/keyboards/hangul-combination-full.xml
+])
+
 AC_OUTPUT
 
 # vim: et

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,7 +1,7 @@
 
 noinst_PROGRAMS = hangul hanja
 
-hangul_CFLAGS =
+hangul_CFLAGS = -DTEST_LIBHANGUL_KEYBOARD_PATH=\"${abs_top_builddir}/data/keyboards\"
 hangul_SOURCES = hangul.c
 hangul_LDADD = ../hangul/libhangul.la $(LTLIBINTL) $(LTLIBICONV)
 
@@ -12,5 +12,9 @@ hanja_LDADD = ../hangul/libhangul.la $(LTLIBINTL)
 TESTS = test
 check_PROGRAMS = test
 test_SOURCES = test.c ../hangul/hangul.h
-test_CFLAGS = $(CHECK_CFLAGS) -DTEST_SOURCE_DIR=\"$(abs_srcdir)\"
+test_CFLAGS =  \
+	$(CHECK_CFLAGS) \
+	-DTEST_SOURCE_DIR=\"$(abs_srcdir)\" \
+	-DTEST_LIBHANGUL_KEYBOARD_PATH=\"${abs_top_builddir}/data/keyboards\" \
+	$(NULL)
 test_LDADD = $(CHECK_LIBS) ../hangul/libhangul.la $(LTLIBINTL)

--- a/test/hangul.c
+++ b/test/hangul.c
@@ -68,6 +68,10 @@ main(int argc, char *argv[])
 	keyboard = argv[1];
     }
 
+    char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
+    if (keyboard_path == NULL)
+        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
+
     hangul_init();
 
     hic = hangul_ic_new(keyboard);

--- a/test/test.c
+++ b/test/test.c
@@ -613,6 +613,10 @@ Suite* libhangul_suite()
 
 int main()
 {
+    char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
+    if (keyboard_path == NULL)
+        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
+
     hangul_init();
 
     int number_failed;


### PR DESCRIPTION
LIBHANGUL_KEYBOARD_PATH 환경 변수를 설정하면 그 위치의
키보드 파일을 로딩하게 한다.

테스트할 때에는 시스템에 설치된 키보드 파일이 아니라
빌드 디렉토리의 키보드 파일을 사용해야 의미가 있다.
빌드 디렉토리의 키보드을 로딩할 수 있는 기능을 제공하기위해서
LIBHANGUL_KEYBOARD_PATH 환경 변수를 도입한다.

소스 디렉토리에는 키보드 파일 템플릿만 있다. 완성된 키보드 파일은
빌드 디렉토리에 생성되므로 빌드 디렉토리에서 키보드 파일을 로딩해야 한다.
그러나 거기에는 combination 파일이 없으므로 제대로된 테스트를
위해서는 combination 파일도 복사해주는 룰이 필요하다.
AC_CONFIG_LINKS()를 사용하여 소스만 고치고도 테스트 가능하게 한다.