### PR TITLE
hanja: Fix dereference of NULL

### DIFF
--- a/hangul/hanja.c
+++ b/hangul/hanja.c
@@ -436,14 +436,18 @@ hanja_table_match(const HanjaTable* table,
 	    char* p = strtok_r(buf, ":", &save);
 	    res = strcmp(p, key);
 	    if (res == 0) {
+                if (*list == NULL) {
+                    *list = hanja_list_new(key);
+                }
+
+                if (*list == NULL) {
+                    break;
+                }
+
 		char* value   = strtok_r(NULL, ":", &save);
 		char* comment = strtok_r(NULL, "\r\n", &save);
 
 		Hanja* hanja = hanja_new(p, value, comment);
-
-		if (*list == NULL) {
-		    *list = hanja_list_new(key);
-		}
 
 		hanja_list_append_n(*list, hanja, 1);
 	    } else if (res > 0) {


### PR DESCRIPTION
Static Analysis에서 발견된 "dereference of NULL" 문제를 수정한다.
HanjaList 메모리 할당에 실패한 경우에 대한 처리가 되지 않고 있었다.
list 할당에 실패한 경우 Hanja 아이템을 추가하지 않게 한다.

https://github.com/libhangul/libhangul/issues/53