### PR TITLE
keyboard: Always specify SUFFIX on sed -i option

### DIFF
--- a/data/keyboards/CMakeLists.txt
+++ b/data/keyboards/CMakeLists.txt
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.2)
 
 #include(GNUInstallDirs)
 find_package(Gettext)
@@ -72,7 +72,7 @@ foreach(i ${keyboard_file_list})
         OUTPUT
             "${keyboard_name}.xml"
         COMMAND
-            sed -i -e '1 D'
+            sed -i.tmp -e '1 D'
                     -e '/^<hangul-keyboard/D'
                     -e '/^<\\/hangul-keyboard/D'
                     -e 's/^ *<name/    <name/' "${keyboard_name}.name.xml"
@@ -81,6 +81,8 @@ foreach(i ${keyboard_file_list})
                     -e '/<name>/r ${keyboard_name}.name.xml'
                     -e '/<name>/D'
                     "${CMAKE_CURRENT_SOURCE_DIR}/${keyboard_name}.xml.template" > "${keyboard_name}.xml"
+        BYPRODUCTS
+            "${keyboard_name}.name.xml.tmp"
         DEPENDS
             "${CMAKE_CURRENT_BINARY_DIR}/${keyboard_name}.name.xml"
             "${keyboard_name}.xml.template"

--- a/data/keyboards/Makefile.am
+++ b/data/keyboards/Makefile.am
@@ -38,7 +38,7 @@ MSGFMT_COMMAND = env GETTEXTDATADIRS=$(srcdir) $(MSGFMT)
 # name.xml로 만들어 (msgfmt 입출력은 valid XML만 가능하므로 root node도 포함.)
 # 번역한후 template과 name.xml을 병합하여 키보드 xml 파일을 생성한다.
 hangul-keyboard-%.xml: hangul-keyboard-%.name.xml hangul-keyboard-%.xml.template
-	sed -i -e '1 D' \
+	sed -i.tmp -e '1 D' \
 		-e '/^<hangul-keyboard/D' \
 		-e '/^<\/hangul-keyboard/D' \
 		-e 's/^ *<name/    <name/'  $<
@@ -66,4 +66,13 @@ CLEANFILES = \
 	hangul-keyboard-3y.xml \
 	hangul-keyboard-ro.xml \
 	hangul-keyboard-ahn.xml \
+	hangul-keyboard-2.name.xml.tmp \
+	hangul-keyboard-2y.name.xml.tmp \
+	hangul-keyboard-39.name.xml.tmp \
+	hangul-keyboard-3f.name.xml.tmp \
+	hangul-keyboard-32.name.xml.tmp \
+	hangul-keyboard-3s.name.xml.tmp \
+	hangul-keyboard-3y.name.xml.tmp \
+	hangul-keyboard-ro.name.xml.tmp \
+	hangul-keyboard-ahn.name.xml.tmp \
 	$(NULL)


### PR DESCRIPTION
On macOS, `sed -i` without SUFFIX option reports an error:
```
sed: -e: No such file or directory
```

hangul-keyboard-*.name.xml.tmp are intermediate files.
They should be cleaned.

BYPRODUCTS option is simpler to use than ADDITIONAL_MAKE_CLEAN_FILES.
It is available from 3.2.

https://github.com/libhangul/libhangul/issues/63