### PR TITLE
hangul_init: Add user_defined_keyboard_path argument

### DIFF
--- a/hangul/hangul.h
+++ b/hangul/hangul.h
@@ -96,7 +96,7 @@ enum {
 };
 
 /* library */
-int hangul_init();
+int hangul_init(const char* user_defined_keyboard_path);
 int hangul_fini();
 
 /* keyboard */

--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -1587,21 +1587,24 @@ hangul_ic_is_transliteration(HangulInputContext *hic)
 
 /**
  * @ingroup hangulic
- * @breif libhangul을 초기화 하는 함수.
+ * @brief libhangul을 초기화 하는 함수.
+ * @param user_defined_keyboard_path 한글 키보드 파일을 읽을 디렉토리 패스.
+ *        PATH 환경 변수와 같이 :으로 구분하여 여러개를 지정할 수 있다.
+ *        NULL을 주면 내장 기본값을 사용한다.
  *
  * libhangul의 함수를 사용하기 전에 호출해야 한다.
  */
 int
-hangul_init()
+hangul_init(const char* user_defined_keyboard_path)
 {
     int res;
-    res = hangul_keyboard_list_init();
+    res = hangul_keyboard_list_init(user_defined_keyboard_path);
     return res;
 }
 
 /**
  * @ingroup hangulic
- * @breif libhangul에서 사용한 리소스를 해제하는 함수.
+ * @brief libhangul에서 사용한 리소스를 해제하는 함수.
  *
  * libhangul의 함수의 사용이 끝나면 호출해야 한다.
  */

--- a/hangul/hangulinternals.h
+++ b/hangul/hangulinternals.h
@@ -35,7 +35,7 @@ ucschar hangul_keyboard_combine(const HangulKeyboard* keyboard,
 ucschar hangul_keyboard_get_mapping(const HangulKeyboard* keyboard,
 	    int tableid, unsigned key);
 
-int hangul_keyboard_list_init();
+int hangul_keyboard_list_init(const char* user_defined_keyboard_path);
 int hangul_keyboard_list_fini();
 
 const HangulKeyboard* hangul_keyboard_list_get_keyboard(const char* id);

--- a/hangul/hangulkeyboard.c
+++ b/hangul/hangulkeyboard.c
@@ -888,7 +888,7 @@ hangul_keyboard_get_keyboard_path()
 }
 
 int
-hangul_keyboard_list_init()
+hangul_keyboard_list_init(const char* user_defined_keyboard_path)
 {
 #if ENABLE_EXTERNAL_KEYBOARDS
     /* 이 함수를 중복 호출할 경우에 대한 처리
@@ -903,7 +903,12 @@ hangul_keyboard_list_init()
     hangul_builtin_keyboard_count = 0;
 
     /* libhangul data dir에서 keyboard 로딩 */
-    char* libhangul_keyboard_path = hangul_keyboard_get_keyboard_path();
+    char* libhangul_keyboard_path = NULL;
+    if (user_defined_keyboard_path == NULL) {
+        libhangul_keyboard_path = hangul_keyboard_get_keyboard_path();
+    } else {
+        libhangul_keyboard_path = strdup(user_defined_keyboard_path);
+    }
 
     unsigned n = 0;
 

--- a/test/hangul.c
+++ b/test/hangul.c
@@ -68,11 +68,7 @@ main(int argc, char *argv[])
 	keyboard = argv[1];
     }
 
-    char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
-    if (keyboard_path == NULL)
-        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
-
-    hangul_init();
+    hangul_init(TEST_LIBHANGUL_KEYBOARD_PATH);
 
     hic = hangul_ic_new(keyboard);
     if (hic == NULL) {

--- a/test/test.c
+++ b/test/test.c
@@ -613,11 +613,7 @@ Suite* libhangul_suite()
 
 int main()
 {
-    char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
-    if (keyboard_path == NULL)
-        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
-
-    hangul_init();
+    hangul_init(TEST_LIBHANGUL_KEYBOARD_PATH);
 
     int number_failed;
     Suite* s = libhangul_suite();

--- a/tools/hangul.c
+++ b/tools/hangul.c
@@ -295,7 +295,7 @@ main(int argc, char *argv[])
 
     setlocale(LC_ALL, "");
 
-    hangul_init();
+    hangul_init(NULL);
 
     res = EXIT_SUCCESS;
     keyboard = "2";


### PR DESCRIPTION
키보드 파일 위치를 환경 변수로만 조정하는 것보다 hangul_init()
함수에서 직접 키보드 파일 위치를 지정할 수 있는 편이 라이브러리
사용에 편리한 것 같다.