### PR TITLE
keyboard: Add hangul_ic_switch_keyboard_table() api

### DIFF
--- a/hangul/hangul.h
+++ b/hangul/hangul.h
@@ -138,6 +138,7 @@ void hangul_ic_set_keyboard(HangulInputContext *hic,
 			    const HangulKeyboard *keyboard);
 void hangul_ic_select_keyboard(HangulInputContext *hic,
 			       const char* id);
+void hangul_ic_switch_keyboard_table(HangulInputContext *hic, int table_id);
 void hangul_ic_connect_callback(HangulInputContext* hic, const char* event,
 				void* callback, void* user_data);
 

--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -197,6 +197,7 @@ struct _HangulInputContext {
     int type;
 
     const HangulKeyboard*    keyboard;
+    int keyboard_table_id;
 
     HangulBuffer buffer;
     int output_mode;
@@ -1079,7 +1080,7 @@ hangul_ic_process(HangulInputContext *hic, int ascii)
     hic->preedit_string[0] = 0;
     hic->commit_string[0] = 0;
 
-    c = hangul_keyboard_get_mapping(hic->keyboard, 0, ascii);
+    c = hangul_keyboard_get_mapping(hic->keyboard, hic->keyboard_table_id, ascii);
     if (hic->on_translate != NULL)
 	hic->on_translate(hic, ascii, &c, hic->on_translate_data);
 
@@ -1464,6 +1465,16 @@ hangul_ic_select_keyboard(HangulInputContext *hic, const char* id)
 
     keyboard = hangul_keyboard_list_get_keyboard(id);
     hic->keyboard = keyboard;
+    hic->keyboard_table_id = 0;
+}
+
+void
+hangul_ic_switch_keyboard_table(HangulInputContext *hic, int table_id)
+{
+    if (hic == NULL)
+        return;
+
+    hic->keyboard_table_id = table_id;
 }
 
 void
@@ -1492,6 +1503,9 @@ hangul_ic_new(const char* keyboard)
     hic = malloc(sizeof(HangulInputContext));
     if (hic == NULL)
 	return NULL;
+
+    hic->keyboard = NULL;
+    hic->keyboard_table_id = 0;
 
     hic->preedit_string[0] = 0;
     hic->commit_string[0] = 0;

--- a/hangul/hangulkeyboard.c
+++ b/hangul/hangulkeyboard.c
@@ -427,18 +427,18 @@ hangul_keyboard_set_name(HangulKeyboard* keyboard, const char* name)
 }
 
 ucschar
-hangul_keyboard_get_mapping(const HangulKeyboard* keyboard, int tableid, unsigned key)
+hangul_keyboard_get_mapping(const HangulKeyboard* keyboard, int table_id, unsigned key)
 {
     if (keyboard == NULL)
 	return 0;
 
-    if (tableid >= countof(keyboard->table))
-	return 0;
+    if (table_id >= countof(keyboard->table))
+        return 0;
 
     if (key >= HANGUL_KEYBOARD_TABLE_SIZE)
 	return 0;
 
-    ucschar* table = keyboard->table[tableid];
+    ucschar* table = keyboard->table[table_id];
     if (table == NULL)
 	return 0;
 
@@ -446,18 +446,18 @@ hangul_keyboard_get_mapping(const HangulKeyboard* keyboard, int tableid, unsigne
 }
 
 static void
-hangul_keyboard_set_mapping(HangulKeyboard *keyboard, int tableid, unsigned key, ucschar value)
+hangul_keyboard_set_mapping(HangulKeyboard *keyboard, int table_id, unsigned key, ucschar value)
 {
     if (keyboard == NULL)
 	return;
 
-    if (tableid >= countof(keyboard->table))
-	return;
+    if (table_id >= countof(keyboard->table))
+        return;
 
     if (key >= HANGUL_KEYBOARD_TABLE_SIZE)
 	return;
 
-    if (keyboard->table[tableid] == NULL) {
+    if (keyboard->table[table_id] == NULL) {
 	ucschar* new_table = malloc(sizeof(ucschar) * HANGUL_KEYBOARD_TABLE_SIZE);
 	if (new_table == NULL)
 	    return;
@@ -466,10 +466,10 @@ hangul_keyboard_set_mapping(HangulKeyboard *keyboard, int tableid, unsigned key,
 	for (i = 0; i < HANGUL_KEYBOARD_TABLE_SIZE; ++i) {
 	    new_table[i] = 0;
 	}
-	keyboard->table[tableid] = new_table;
+        keyboard->table[table_id] = new_table;
     }
 
-    ucschar* table = keyboard->table[tableid];
+    ucschar* table = keyboard->table[table_id];
     table[key] = value;
 }
 


### PR DESCRIPTION
HangulKeyboard is support 4 keycode-to-char mapping table. A new api hangul_ic_switch_keyboard_table() changes the current mapping table according to the specified table id.

Change tableid to table_id for varible name consistency.