### PR TITLE
자동 순서 교정 기능이 켜져있을 때 자소 방식 입력에서는 모음을 연속으로 입력하지 않아도 모음끼리 결합될 수 있도록 합니다

### DIFF
--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -810,7 +810,7 @@ hangul_ic_process_jaso(HangulInputContext *hic, ucschar ch)
 	    }
 	} else {
 	    ucschar jungseong = 0;
-	    if (hangul_is_jungseong(hangul_ic_peek(hic))) {
+	    if (hic->option_auto_reorder || hangul_is_jungseong(hangul_ic_peek(hic))) {
 		jungseong = hangul_ic_combine(hic, hic->buffer.jungseong, ch);
 	    }
 	    if (jungseong) {


### PR DESCRIPTION
자소 입력 방식(세벌식)은 자모 입력 방식(두벌식)과 다르게 모음이 연속적으로 입력되지 않은 경우에도 조합 여부를 판단할 수 있습니다.
이 수정은 입력 과정에서 두 모음 사이에 다른 글자가 입력된 경우에도 자동 순서 교정 기능이 입력을 교정하도록 합니다. (ㅜ -> ㄱ -> ㅣ = 귀)