### PR TITLE
Win32 support

### DIFF
--- a/hangul/hangulinputcontext.c
+++ b/hangul/hangulinputcontext.c
@@ -21,7 +21,11 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <strings.h>
+#else
+#define strcasecmp _stricmp
+#endif
 #include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/hangul/hangulkeyboard.c
+++ b/hangul/hangulkeyboard.c
@@ -35,6 +35,10 @@
 #include "hangul.h"
 #include "hangulinternals.h"
 
+#ifdef _WIN32
+#define strdup _strdup
+#endif
+
 /**
  * @file hangulkeyboard.c
  */
@@ -831,6 +835,7 @@ hangul_keyboard_list_clear()
     hangul_keyboards.keyboards = NULL;
 }
 
+#if ENABLE_EXTERNAL_KEYBOARDS
 static char*
 hangul_keyboard_get_default_keyboard_path()
 {
@@ -886,6 +891,7 @@ hangul_keyboard_get_keyboard_path()
 
     return keyboard_path;
 }
+#endif /* ENABLE_EXTERNAL_KEYBOARDS */
 
 int
 hangul_keyboard_list_init()

--- a/hangul/hanja.c
+++ b/hangul/hanja.c
@@ -22,7 +22,12 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <unistd.h>
+#else
+#include <io.h>
+#define strtok_r strtok_s
+#endif
 
 #ifdef HAVE_MMAP
 #include <sys/mman.h>

--- a/hangul/hanja.c
+++ b/hangul/hanja.c
@@ -495,7 +495,11 @@ hanja_table_load(const char* filename)
     HanjaTable* table;
 
     if (filename == NULL)
+#ifdef LIBHANGUL_DEFAULT_HANJA_DIC
 	filename = LIBHANGUL_DEFAULT_HANJA_DIC;
+#else
+	return NULL;
+#endif /* LIBHANGUL_DEFAULT_HANJA_DIC */
 
     file = fopen(filename, "r");
     if (file == NULL) {

--- a/libhangul.vcxproj
+++ b/libhangul.vcxproj
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{83381EEE-8813-47E6-BDCB-4F9882E81882}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libhangul</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <SpectreMitigation>false</SpectreMitigation>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>.;.\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;ENABLE_EXTERNAL_KEYBOARDS=0;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>.;.\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;ENABLE_EXTERNAL_KEYBOARDS=0;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>.;.\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_LIB;ENABLE_EXTERNAL_KEYBOARDS=0;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>.;.\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_LIB;ENABLE_EXTERNAL_KEYBOARDS=0;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="hangul\hangul.h" />
+    <ClInclude Include="hangul\hangul-gettext.h" />
+    <ClInclude Include="hangul\hangulinternals.h" />
+    <ClInclude Include="hangul\hangulkeyboard.h" />
+    <ClInclude Include="hangul\hanjacompatible.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="hangul\hangulctype.c" />
+    <ClCompile Include="hangul\hangulinputcontext.c" />
+    <ClCompile Include="hangul\hangulkeyboard.c" />
+    <ClCompile Include="hangul\hanja.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/libhangul.vcxproj
+++ b/libhangul.vcxproj
@@ -139,6 +139,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemGroup Condition="'$(ConfigurationType)'=='DynamicLibrary'">
+    <ResourceCompile Include="win32\libhangul.rc" />
+  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="hangul\hangul.h" />
     <ClInclude Include="hangul\hangul-gettext.h" />

--- a/test/hangul.c
+++ b/test/hangul.c
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
 
     char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
     if (keyboard_path == NULL)
-        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
+        putenv("LIBHANGUL_KEYBOARD_PATH=" TEST_LIBHANGUL_KEYBOARD_PATH);
 
     hangul_init();
 

--- a/test/test.c
+++ b/test/test.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <wchar.h>
 #include <check.h>
 
@@ -528,6 +529,7 @@ START_TEST(test_syllable_iterator)
 }
 END_TEST
 
+#if ENABLE_EXTERNAL_KEYBOARDS
 START_TEST(test_hangul_keyboard)
 {
     const char* id;
@@ -575,6 +577,7 @@ START_TEST(test_hangul_keyboard)
     hangul_keyboard_delete(keyboard);
 }
 END_TEST
+#endif /* ENABLE_EXTERNAL_KEYBOARDS */
 
 START_TEST(test_hangul_jamo_to_cjamo)
 {
@@ -604,7 +607,9 @@ Suite* libhangul_suite()
     tcase_add_test(hangul, test_hangul_ic_combi_on_double_stroke);
     tcase_add_test(hangul, test_hangul_ic_non_choseong_combi);
     tcase_add_test(hangul, test_syllable_iterator);
+#if ENABLE_EXTERNAL_KEYBOARDS
     tcase_add_test(hangul, test_hangul_keyboard);
+#endif /* ENABLE_EXTERNAL_KEYBOARDS */
     tcase_add_test(hangul, test_hangul_jamo_to_cjamo);
     suite_add_tcase(s, hangul);
 
@@ -615,7 +620,7 @@ int main()
 {
     char* keyboard_path = getenv("LIBHANGUL_KEYBOARD_PATH");
     if (keyboard_path == NULL)
-        setenv("LIBHANGUL_KEYBOARD_PATH", TEST_LIBHANGUL_KEYBOARD_PATH, 1);
+        putenv("LIBHANGUL_KEYBOARD_PATH=" TEST_LIBHANGUL_KEYBOARD_PATH);
 
     hangul_init();
 

--- a/win32/libhangul.rc
+++ b/win32/libhangul.rc
@@ -1,0 +1,46 @@
+
+#undef APSTUDIO_READONLY_SYMBOLS
+#include <winver.h>
+#include "../hangul/hangul.h"
+#undef APSTUDIO_READONLY_SYMBOLS
+
+// English resources
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION 1,0,0,0
+  PRODUCTVERSION 1,0,0,0
+  FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+  FILEFLAGS 0xbL
+#else
+  FILEFLAGS 0xaL
+#endif
+  FILEOS 0x4L
+  FILETYPE VFT_DLL
+  FILESUBTYPE 0xbL
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "Comments", "libhangul hangul library https://github.com/libhangul/libhangul\0"
+      VALUE "CompanyName", "libhangul\0"
+      VALUE "FileDescription", "Libhangul v1.0.0\0"
+      VALUE "FileVersion", "1.0\0"
+      VALUE "InternalName", "Libhangul\0"
+      VALUE "LegalCopyright", "Copyright (C) 2004-2022 Choe Hwanjin\0"
+      VALUE "LegalTrademarks", "\0"
+      VALUE "OriginalFilename", "LIBHANGUL.DLL\0"
+      VALUE "ProductName", "Libhangul\0"
+      VALUE "ProductVersion", "1.0.0.0\0"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1252
+  END
+END
+
+#endif // English resources


### PR DESCRIPTION
~~***WIP***~~ **DONE**
VS vcxproj 추가 및 WIN32 지원을 위한 변경을 추가했습니다.
* `DynamicLibrary`지원 (`msbuild -p:configurationtype=dynamiclibrary`)
* `glob` 지원 문제로 `ENABLE_EXTERNAL_KEYBOARDS`는 비활성화

그밖에, `cmake` + MSYS(mingw64) 지원은 몇가지(?) 문제로 제대로 빌드가 안되지만,

- cmake+리눅스+mingw64빌드: 리눅스상에서 mingw64 cross tool 세팅하고 `cmake -DENABLE_EXTERNAL_KEYBOARDS=0 ..` 하면 빌드가 잘 됩니다.
- automake/autoconf + 윈도우10 + MSYS: WIN32 build fix 커밋을 적용하면, mingw64빌드는 잘 작동합니다. `configure --disable-external-keyboards`

See also https://github.com/navilera/libhangul 최근(?) 작업도 참고하였습니다.