### PR TITLE
두벌식 옛글 자판에 방점 추가

### DIFF
--- a/hangul/hangulkeyboard.h
+++ b/hangul/hangulkeyboard.h
@@ -232,11 +232,11 @@ static const ucschar hangul_keyboard_table_2y[] = {
     0x1101,     /* 0x52 R:            choseong ssangkiyeok           */
     0x115d,     /* 0x53 S:            choseong nieun-hieuh           */
     0x110a,     /* 0x54 T:            choseong ssangsios             */
-    0x1167,     /* 0x55 U:            jungseong yeo                  */
+    0x302f,     /* 0x55 U:            hangul double dot tone mark    */
     0x1150,     /* 0x56 V:            choseong ceongchieumcieuc      */
     0x110d,     /* 0x57 W:            choseong ssangcieuc            */
     0x113e,     /* 0x58 X:            choseong ceongchieumsios       */
-    0x116d,     /* 0x59 Y:            jungseong yo                   */
+    0x302e,     /* 0x59 Y:            hangul single dot tone mark    */
     0x113c,     /* 0x5A Z:            choseong chitueumsios          */
     0x0000,     /* 0x5B bracketleft:  left bracket                   */
     0x0000,     /* 0x5C backslash:    backslash                      */


### PR DESCRIPTION
안녕하세요, 평소에 잘 사용하고 있는데, 한가지 아쉬운 점이 두벌식 옛글 자판에 방점 (〮, 〯)를 입력할 방법이 없다는 것이었습니다.

그런데 날개셋 입력기의 경우 Shift+Y와 U 키에 이 두 방점 기호가 배정돼 있는데, libhangul의 두벌식 옛글 자판의 경우 이 두 자리에 아무것도 배정되어 있지 않은 것을 발견하여, 이 자리에 방점을 배정하는 것이 옳을 것으로 생각됩니다.