### PR TITLE
cmake: Fix install directory for `.pc` file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/libhangul.pc"
     DESTINATION
-        "${CMAKE_INSTALL_LIBDIR}/pkgconfig/libhangul.pc"
+        "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     COMPONENT
         dev
 )


### PR DESCRIPTION
The `DESTINATION` option of the CMake `install()` command must specify a directory.