### PR TITLE
cmake: make tools optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ option(ENABLE_UNIT_TEST
     ON
 )
 
+option(ENABLE_TOOLS
+    "Enable/Disable tools."
+    ON
+)
+
 include(CTest)
 
 include(GNUInstallDirs)
@@ -52,7 +57,9 @@ add_subdirectory(data/hanja)
 if(ENABLE_EXTERNAL_KEYBOARDS)
 add_subdirectory(data/keyboards)
 endif()
+if(ENABLE_TOOLS)
 add_subdirectory(tools)
+endif()
 add_subdirectory(po)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
The tool may be intended to be used on desktop. When cross build for Android and wasm, the tool cannot be meaningfully used. We are using patches ([1](https://github.com/fcitx5-android/prebuilder/blob/0dbe74a6ba081a61b9be0db87953967fdac9769b/patches/libhangul.patch), [2](https://github.com/fcitx-contrib/fcitx5-prebuilder/blob/cbaae50c63eff0226a559dac1ed40af9a4fcb274/patches/libhangul.patch)) so would like to upstream.