### PR TITLE
Fix hanja table loading on Windows (MSVC text-mode ftell drift)

### DIFF
--- a/hangul/hanja.c
+++ b/hangul/hanja.c
@@ -501,7 +501,7 @@ hanja_table_load(const char* filename)
 	return NULL;
 #endif /* LIBHANGUL_DEFAULT_HANJA_DIC */
 
-    file = fopen(filename, "r");
+    file = fopen(filename, "rb");
     if (file == NULL) {
 	return NULL;
     }


### PR DESCRIPTION
## Problem

On Windows with MSVC, `hanja_table_load()` opens `hanja.txt` in text mode (`fopen("r")`) and records each key-block offset with `ftell()`. When the file uses LF-only line endings, MSVC text mode causes `ftell()` to return incorrect offsets — it over-counts by the number of preceding newlines, because MSVC text mode assumes CRLF (2 bytes per newline) but hanja.txt uses LF (1 byte per newline).

When `hanja_table_seek_key()` later calls `fseek()` with these offsets, it lands in the **middle** of a key block instead of at the start. The first token comparison then fails immediately, and the function returns **0 candidates for most hangul syllables**.

## Fix

Change `fopen(filename, "r")` to `fopen(filename, "rb")` in `hanja_table_load()`. Binary mode makes `ftell()`/`fseek()` agree on raw byte positions. **This is a no-op on Linux/macOS**, where text and binary mode are identical for LF-only files.

## Verification

Built NabiCloud (Windows TSF IME using libhangul) with MSVC on Windows 11.

| Character | Before fix | After fix |
|-----------|------------|-----------|
| 기 (U+AE30) | 0 candidates | 307 candidates |
| 한 (U+D55C) | 0 candidates | 100 candidates |
| 살 (U+C0B4) | 0 candidates |  17 candidates |

Counts match expected dictionary entries.

Also verified via a standalone C harness (`hangul_ic_new("3gs")` + `hanja_table_match_exact()`) to confirm the fix is engine-side, not application-side.
